### PR TITLE
4th Commit:単体試験報告箇所の不具合修正

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
@@ -58,4 +58,17 @@ public class ErrorMessage {
 	//更新対象が見つからなかった場合のエラーメッセージ
 	public static final String NOT_FOUND_UPDATE_ERROR_MESSAGE = "notfound.update";
 
+	//検索対象が見つからなかった場合のエラーメッセージ
+	public static final String NOT_FOUND_SEARCH_ERROR_MESSAGE = "data.empty";
+	
+	//検索時の予期せぬエラーメッセージ
+	public static final String UNEXPECTED_SEARCH_ERROR_MESSAGE = "unexpectedError.search";
+	
+	//部品在庫登録時の空欄を検知した際のエラーメッセージ
+	public static final String STOCKPARTS_NAME_REQUIRED = "{stockParts.name.required}";
+	public static final String STOCKPARTS_INPUT_NAME_ERROR_MESSAGE = "{stockParts.name.invalid.input}";
+	public static final String STOCKPARTS_INPUT_DESCRIPTION_ERROR_MESSAGE = "{stockParts.description.invalid.input}";
+	public static final String STOCKPARTS_NAME_INVALID_LENGTH = "{stockParts.name.length.wrongInput}";
+	public static final String STOCKPARTS_DESCRIPTION_INVALID_LENGTH = "{stockParts.description.length.wrongInput}";
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ModelAttributeContents.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ModelAttributeContents.java
@@ -46,4 +46,10 @@ public class ModelAttributeContents {
 	
 	public static final String STOCK_PARTS_FORM = "partsInfoForm";
 
+	//登録エラー
+	public static final String STOCK_PARTS_ITEM_STOCKNAME = "stockName";
+	public static final String STOCK_PARTS_ITEM_DESCRIPTION = "stockDescription";
+	public static final String STOCK_PARTS_ITEM_AMOUNTVALUE = "amountValue";
+
+	
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/StockParts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/StockParts.java
@@ -1,0 +1,25 @@
+package com.digitalojt.web.consts;
+
+/**
+ * 登録部品情報に関するEnum
+ * 
+ * @author akira morita
+ *
+ */
+
+public enum StockParts {
+
+	NAME("名称"),
+	DESCRIPTION("説明"),
+	AMOUNTS("個数");
+
+	private final String stockPartsItem;
+
+	StockParts(String name) {
+		this.stockPartsItem = name;
+	}
+
+	public String getName() {
+		return stockPartsItem;
+	}
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/StockListController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/StockListController.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import jakarta.validation.Valid;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Controller;
@@ -56,7 +57,9 @@ public class StockListController extends AbstractController {
 	// Centerのサービス
 	private final CenterInfoService centerService;
 	
+	
 	 // メッセージソースを定義
+	@Autowired
     private final MessageSource messageSource;	
 	
 	/**
@@ -109,11 +112,28 @@ public class StockListController extends AbstractController {
 	
 	//検索処理
 	@GetMapping(UrlConsts.STOCK_LIST_SEARCH)
-	public String search(StockListSearchForm form, Model model) {
-	//public String search(StockListSearchForm form, Model model, RedirectAttributes redirectAttributes) {
-
+	public String search(@Valid StockListSearchForm form, BindingResult bindingResult, Model model) {
+		
 	//ログ取得
 	logStart(LogMessage.HTTP_GET);
+	
+	//START -- 障害ID:002対応：バリデーションエラーチェックを追加 -- 
+	if (bindingResult.hasErrors()) {
+	    setCommonModel(model);
+	    model.addAttribute(ModelAttributeContents.STOCK_LIST_SEARCH_FORM, form);
+	    
+        // エラーメッセージを手動で詰め替える（最初のエラーだけ例として表示）
+        String error = bindingResult.getFieldErrors().stream()
+                .map(e -> e.getDefaultMessage())
+                .findFirst()
+                //保険で入れておく
+                .orElse(ErrorMessage.UNEXPECTED_SEARCH_ERROR_MESSAGE);
+
+        model.addAttribute(ModelAttributeContents.ERROR_MSG , error);
+        
+	    return UrlConsts.STOCK_LIST_INDEX;
+	}
+	//END -- 障害ID:002対応： -- 
 	    
 	    model.addAttribute(ModelAttributeContents.STOCK_LIST_SEARCH_FORM, form);
 	    
@@ -127,7 +147,19 @@ public class StockListController extends AbstractController {
 	            form.getComparisonType(),
 	            form.getDeleteFlag());
 	    
-	        model.addAttribute(ModelAttributeContents.STOCK_LIST, results);
+	    
+	    //START -- 障害ID:001対応：検索結果が0件だった時のメッセージ出力処理を実装 --
+	    if (results.isEmpty()) {
+	    	
+	    	String message = messageSource.getMessage(ErrorMessage.NOT_FOUND_SEARCH_ERROR_MESSAGE, null, Locale.getDefault());
+	        model.addAttribute(ModelAttributeContents.ERROR_MSG, message);
+
+	    } else {
+
+		    model.addAttribute(ModelAttributeContents.STOCK_LIST, results);
+
+	    }
+	    //END -- 障害ID:001対応 --
 
 	 //ログ取得終了
 	 logEnd(LogMessage.HTTP_GET);
@@ -172,14 +204,16 @@ public class StockListController extends AbstractController {
 		// 入力時のバリデーションチェック
 		if(bindingResult.hasErrors()) {
 
-		    // バリデーションエラーメッセージ取得をredirectAttributesに追加
-			String errorMessage = getValidationErrorMessage(bindingResult);
-
+			//START -- 障害ID:003,004対応：バリデーションエラーメッセージを改修 -- 
+		    // 共通メソッド呼び出し：バリデーションエラーメッセージ出力処理		
+			String errorMessage = buildValidationErrorMessage(bindingResult);
+			// エラーメッセージを画面に渡す
+		    redirectAttributes.addFlashAttribute(ModelAttributeContents.ERROR_MSG, errorMessage);
+		    //END -- 障害ID:003,004対応 -- 
+			
 			// ログ出力:バリデーションエラー
 			logValidationError(LogMessage.HTTP_POST,errorMessage);	
 		
-			// エラーメッセージを画面に渡す
-			redirectAttributes.addFlashAttribute(ModelAttributeContents.ERROR_MSG,errorMessage);
 		
 			// 部品在庫一覧画面にリダイレクト ERROR_MSGを渡す
 			return "redirect:" + UrlConsts.STOCK_LIST_REGISTER; //部品在庫一覧 登録画面にリダイレクト
@@ -251,8 +285,7 @@ public class StockListController extends AbstractController {
      *  @param model Modelオブジェクト
 	 *	@return String(Viewの名前：部品在庫一覧画面)
 	
-	*/
-		
+	*/		
 	// 更新/削除画面を表示する
 	@GetMapping(UrlConsts.STOCK_LIST_UPDATE_WITHID)
 	public String viewUpdate(Model model, @PathVariable(StockListFields.STOCK_ID) Integer stockId, PartsInfoForm form,
@@ -323,16 +356,31 @@ public class StockListController extends AbstractController {
 		// 入力値のバリデーションチェック
 		if(bindingResult.hasErrors()) {
 			
-			// バリデーションエラーメッセージ取得をredirectAttributesに追加
-			redirectAttributes.addFlashAttribute(ModelAttributeContents.ERROR_MSG,
-					getValidationErrorMessage(bindingResult));
+		  //START -- 障害ID:004対応：バリデーションエラーメッセージを改修 -- 
+		    // 共通メソッド呼び出し：バリデーションエラーメッセージ出力処理		
+			String errorMessage = buildValidationErrorMessage(bindingResult);			
+			// エラーメッセージを画面に渡す
+		    redirectAttributes.addFlashAttribute(ModelAttributeContents.ERROR_MSG, errorMessage);
+		    //END -- 障害ID:0004対応 -- 
 
 			// フォームデータも渡す
 		    redirectAttributes.addFlashAttribute(ModelAttributeContents.STOCK_PARTS_FORM, form);
 
 			// 部品在庫一覧 更新/削除画面にリダイレクト
 			return "redirect:" + UrlConsts.STOCK_LIST_REGISTER;
+												
  		}
+		
+		// START -- 障害ID:006対応：更新時、名称重複登録チェック処理を追加 -- 
+		try {
+		    service.updateStockList(form);
+		} catch (IllegalArgumentException e) {
+		    redirectAttributes.addFlashAttribute(ModelAttributeContents.ERROR_MSG, e.getMessage());
+		    redirectAttributes.addFlashAttribute(ModelAttributeContents.STOCK_PARTS_FORM, form);
+		    return "redirect:" + UrlConsts.STOCK_LIST_REGISTER;
+		}
+	    // END -- 障害ID:0006対応 -- 
+
 		
 		// 部品在庫情報を更新		
 	    service.updateStockList(form);
@@ -357,25 +405,6 @@ public class StockListController extends AbstractController {
 	}
 	
 	
-	//バリデーションエラーメッセージを取得する
-	private String getValidationErrorMessage(BindingResult bindingResult) {
-
-	    StringBuilder errorMessage = new StringBuilder();
-
-	    // フィールドごとのエラーメッセージを取得し、リストに格納
-	    bindingResult.getFieldErrors().forEach(error -> {
-	        errorMessage.append(error.getDefaultMessage()).append("<br>"); // メッセージを改行で区切って追加 (HTML表示を考慮)
-	    });
-
-	    // グローバルエラーメッセージを取得
-	    bindingResult.getGlobalErrors().forEach(error -> {
-	        errorMessage.append(error.getDefaultMessage()).append("<br>");
-	    });
-
-	    return errorMessage.toString();
-	    
-	}
-	
 	//ヘルパーメソッドとして共通化
 	private void setCommonModel(Model model) {
 	    // カテゴリー
@@ -391,6 +420,22 @@ public class StockListController extends AbstractController {
 	    Map<Integer, String> centerMap = centerList.stream()
 	        .collect(Collectors.toMap(CenterInfo::getCenterId, CenterInfo::getCenterName));
 	    model.addAttribute("centerMap", centerMap);
-	}	
+	}
+	
+	
+	
+    //START -- 障害ID:001,002,003対応：バリデーションエラーメッセージを改修 --
+	  //共通メソッドとして以下を追加
+	  // バリデーションエラーメッセージを出力するメソッド
+    public static String buildValidationErrorMessage(BindingResult bindingResult) {
+    	
+    	// バリデーションエラーメッセージ取得をredirectAttributesに追加			
+
+        return bindingResult.getAllErrors().stream()
+                .map(error -> error.getDefaultMessage())
+                .collect(Collectors.joining("<br>"));
+    }
+   //END -- 障害ID:001,002,003対応 -- 
+
 	
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/PartsInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/PartsInfoForm.java
@@ -1,0 +1,72 @@
+package com.digitalojt.web.form;
+
+import java.sql.Timestamp;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import com.digitalojt.web.consts.ErrorMessage;
+
+import lombok.Data;
+
+/*
+部品在庫一覧 登録画面のフォームクラス
+*/
+
+@Data
+//@PartsCategoryFormValidator バリデーションつける
+public class PartsInfoForm {
+
+	/*		
+	部品在庫ID	
+	 */
+	private Integer stockId;
+
+	/*		
+	部品カテゴリーID	
+	 */
+	private Integer categoryId;
+	
+	
+	// 部品在庫名
+	@NotBlank(message = ErrorMessage.STOCKPARTS_NAME_REQUIRED)
+	@Size(max = 20, message = ErrorMessage.STOCKPARTS_NAME_INVALID_LENGTH)
+	@Pattern(regexp = "^[^\\s{}()'*;$&=]*$", message = ErrorMessage.STOCKPARTS_INPUT_NAME_ERROR_MESSAGE)	
+	private String stockName;
+
+	/*		
+	在庫センターID	
+	 */
+	private Integer centerId;
+
+	// 部品説明
+	@Size(max = 100, message = ErrorMessage.STOCKPARTS_DESCRIPTION_INVALID_LENGTH)
+	@Pattern(regexp = "^[^\\s{}()'*;$&=]*$", message = ErrorMessage.STOCKPARTS_INPUT_DESCRIPTION_ERROR_MESSAGE)	
+	private String stockDescription;
+	
+
+	/*		
+	部品在庫数	
+	 */
+	private Integer stockAmounts;
+
+	/*		
+	部品在庫数オプション(以上or以下)	
+	 */
+	private String amountType;
+
+	/*		
+	作成日付		
+	 */
+	private Timestamp createDate;
+
+	/*			
+	更新日付		
+	 */
+	private Timestamp updateDate;	
+	
+	//削除フラグ
+	private Boolean deleteFlag;
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/StockListSearchForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/StockListSearchForm.java
@@ -19,8 +19,8 @@ public class StockListSearchForm {
 	private Integer categoryId;
 	
 	// 部品在庫名
-	@Size(max = 20, message = ErrorMessage.CATEGORY_NAME_INVALID_LENGTH)
-	@Pattern(regexp = "^[^{}()'*;$&=]*$", message = ErrorMessage.INVALID_INPUT_ERROR_MESSAGE)		
+	@Size(max = 20, message = ErrorMessage.STOCKPARTS_NAME_REQUIRED)
+	@Pattern(regexp = "^[^\\s{}()'*;$&=]*$", message = ErrorMessage.INVALID_INPUT_ERROR_MESSAGE)	
     private String stockName;
 
     // 個数   

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/StockListInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/StockListInfoRepository.java
@@ -28,4 +28,8 @@ JpaSpecificationExecutor<StockList> {
 	
 	StockList getByStockName(String stockName);
 
+	
+	// START -- 障害ID:006対応：更新時、名称重複登録チェック処理を追加 -- 
+	boolean existsByStockNameAndStockIdNot(String stockName, Integer stockId);
+	// END -- 障害ID:006対応 -- 
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/StockListService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/StockListService.java
@@ -186,6 +186,15 @@ public class StockListService extends AbstractService{
 		    );
 		}
 		
+		// START -- 障害ID:006対応：更新時、名称重複登録チェック処理を追加 -- 
+		// 重複チェック
+		if (repository.existsByStockNameAndStockIdNot(form.getStockName(), form.getStockId())) {
+		    throw new IllegalArgumentException(
+		        messageSource.getMessage(ErrorMessage.DATA_DUPLICATE_ERROR_MESSAGE,
+		            new Object[]{form.getStockName()}, Locale.getDefault()));
+		}
+		// END -- 障害ID:006対応 -- 
+		
 		 // 中身を取り出す
 		 StockList entity = optional.get();
 		
@@ -208,6 +217,14 @@ public class StockListService extends AbstractService{
 
 	    	// 更新の場合
 	    	entity.setStockName(form.getStockName());
+	    	
+	    	//START -- 障害ID:0005対応：更新する項目を追加 --
+	    	entity.setCategoryId(form.getCategoryId()); 		//カテゴリーID
+	    	entity.setCenterId(form.getCenterId()); 			//センターID
+	    	entity.setDescription(form.getStockDescription());	//説明
+	    	entity.setAmountValue(form.getStockAmounts());		//個数
+	    	//END -- 障害ID:0005対応 --
+
 	    	entity.setDeleteFlag(DeleteFlagConsts.ACTIVE);
 		
 	    }

--- a/DroneInventorySystem/src/main/resources/messages.properties
+++ b/DroneInventorySystem/src/main/resources/messages.properties
@@ -4,6 +4,7 @@ allField.empty=すべてのフィールドが空です。少なくとも1つの�
 unexpected.input=予期せぬ入力を検知しました。
 invalid.input=不正な文字列を検出しました。
 data.empty=検索条件に合致するデータが見つかりませんでした。
+unexpectedError.search=予期せぬ検索エラーを検出しました。
 
 # ログイン画面
 login.wrongInput=ログインIDまたはパスワードが不正です。
@@ -29,3 +30,8 @@ update.success=部品カテゴリー {0} の更新が正常に完了しました
 #部品在庫一覧画面 登録/削除/更新
 registerParts.success=部品在庫 {0} の登録が正常に完了しました。
 updateParts.success=部品在庫 {0} の更新が正常に完了しました。
+stockParts.name.invalid.input=名称に不正な文字列を検出しました。
+stockParts.description.invalid.input=説明に不正な文字列を検出しました。
+stockParts.name.required=部品名が空欄です。名称を入力してください。
+stockParts.name.length.wrongInput=部品名は20文字以内で入力してください。
+stockParts.description.length.wrongInput=部品名は50文字以内で入力してください。


### PR DESCRIPTION
単体試験実施後、下記の報告箇所についての修正を実施しました。
修正後コードレビューをよろしくお願いいたします。

＜改修内容抜粋＞
・障害ID:001 検索結果が0件だった場合、画面にエラーメッセージが出力されていない問題を修正。
・障害ID:002 バリデーションチェックエラーメッセージが正常に出力されていない問題を修正。（半角スペースの判定）
・障害ID:003 登録時、バリデーションチェックエラーメッセージが正常に出力されていない問題を修正。
・障害ID:004 更新時、バリデーションチェックエラーメッセージが正常に出力されていない問題を修正。
・障害ID:005 DB更新処理時、名称と削除フラグ以外の項目に対して行えていなかった問題を修正。
・障害ID:006 DB更新処理時、変更した名称が重複するデータの場合でも、更新処理が実行できてしまう問題を修正。